### PR TITLE
Drop out

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -179,7 +179,7 @@ def send_message(text, chat_id, parse_mode=None, send_keyboard=None):
     
     if send_keyboard:
         url += '&reply_markup={"inline_keyboard":[[{"text":"Physical","callback_data":1}, \
-        {"text":"Remote","callback_data":2},{"text":"Invite","callback_data":3}]]}'
+        {"text":"Remote","callback_data":2},{"text":"Invite","callback_data":3},{"text":"X","callback_data":4}]]}'
     
     http = urllib3.PoolManager()
     resp = http.request('GET', url)
@@ -205,7 +205,7 @@ def edit_message(chat_id, message_id, text, parse_mode=None, send_keyboard=None)
     
     if send_keyboard:
         url += '&reply_markup={"inline_keyboard":[[{"text":"Physical","callback_data":1}, \
-        {"text":"Remote","callback_data":2},{"text":"Invite","callback_data":3},{"text":"X","callback_data":0}]]}'
+        {"text":"Remote","callback_data":2},{"text":"Invite","callback_data":3},{"text":"X","callback_data":4}]]}'
     
     #send_message('{0}'.format(chat_id), 581975002, None)
     

--- a/raid_function.py
+++ b/raid_function.py
@@ -214,7 +214,7 @@ def format_raid_message(raid_dict):
                 invite_str = ''.join(['{0}\n{1}'.format(invite_str, p.get('username')) if not invite_count == 0 else p.get('username')])
                 invite_count += 1
                 
-            elif p.get('participation_type_id') == 0:
+            elif p.get('participation_type_id') == 4:
                 dropout_str = ''.join(['{0}\n{1}'.format(dropout_str, p.get('username')) if not dropout_count == 0 else p.get('username')])
                 dropout_count += 1
                 
@@ -377,14 +377,15 @@ def join_raid(from_object, raid_id, participation_type_id):
     #         They may have changed their participation type
     #         Or just sending a duplicate request which we should ignore
     #         If they are not already participating - then add them
+    #         If they are trying to drop out of a raid they are not in - then ignore
     p = get_raid_participation_by_id(raid_id, from_object['id'])
     if not p:
-        return insert_raid_participation(raid_id, from_object['id'], participation_type_id)
+        if not participation_type_id == '4':
+            return insert_raid_participation(raid_id, from_object['id'], participation_type_id)
     else:
         if p.get('participation_type_id') == int(participation_type_id):
             return False
         else:
             return update_raid_participation(raid_id, from_object['id'], participation_type_id)
     
-    # We should never get here!
     return False


### PR DESCRIPTION
Support for dropping out of a raid (participation type = 4)
A user cannot drop out of a raid they weren't participating in in the first place.